### PR TITLE
Issue 88 update 2019 schedule, closes #88

### DIFF
--- a/_data/global.yml
+++ b/_data/global.yml
@@ -25,7 +25,7 @@ online_ticket_deadline: the morning of Friday, February 22nd
 show_facebook_event: false
 show_online_ticketing: false
 show_alert: false
-show_schedule: false
+show_schedule: true
 show_download_schedule_pdf: false
 schedule_pdf: ""
 show_sponsors: true

--- a/_data/global.yml
+++ b/_data/global.yml
@@ -6,6 +6,7 @@ title: University Salsa Fest 2019
 description: >-
   University Salsa Fest at University of Virginia UVA 2019
 year: 2019
+workshop_count: 7
 
 banner_image: banner-2019.jpg
 

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -1,0 +1,15 @@
+---
+- time: 11:30 AM - 12:20 PM
+  title: Edwin Roa, Charlottesville
+  description: Kizomba
+  description_line_two:
+
+- time: 6:30 - 8:30 PM
+  title: DINNER BREAK
+  description:
+  description_line_two:
+
+- time: 10:30 - 11:00 PM
+  title: Performances
+  description: Featuring University Salsa Club, DNC 2 BEAT, Volante,
+  description_line_two: Yamulee Project DC, Shaka Brown, and Rosalia and Alejandro

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -4,8 +4,43 @@
   description: Kizomba
   description_line_two:
 
+- time: 12:30 PM - 1:20 PM
+  title: Michelle Garcia, Boston
+  description: On2 Salsa Body Movement and Footwork
+  description_line_two:
+
+- time: 1:30 PM - 2:20 PM
+  title: Shaka Brown, DC
+  description: Cha-Cha Jam
+  description_line_two:
+
+- time: 2:30 PM - 3:20 PM
+  title: Brian Le, DC
+  description: Modern/Urban Bachata
+  description_line_two:
+
+- time: 3:30 PM - 4:20 PM
+  title: Rosalia and Alejandro, Buenos Aires, Argentina
+  description: Tango
+  description_line_two:
+
+- time: 4:30 PM - 5:20 PM
+  title: Maria Krupholter, DC
+  description: Salsa On2 Footwork and Partnerwork
+  description_line_two:
+
+- time: 5:30 PM - 6:20 PM
+  title: Stephen Jackson
+  description: Bachata with an Urban Funk and Cha-Cha twist
+  description_line_two:
+
 - time: 6:30 - 8:30 PM
-  title: DINNER BREAK
+  title: Dinner Break
+  description:
+  description_line_two:
+
+- time: 8:30 - 10:30 PM
+  title: Party + Dancing with DJ Stephen Greene
   description:
   description_line_two:
 
@@ -13,3 +48,8 @@
   title: Performances
   description: Featuring University Salsa Club, DNC 2 BEAT, Volante,
   description_line_two: Yamulee Project DC, Shaka Brown, and Rosalia and Alejandro
+
+- time: 11:00 PM - 2:00 AM
+  title: The Party Continues!
+  description:
+  description_line_two:

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -4,52 +4,24 @@
         <a id="schedule"></a>
         <h2 class="featurette-heading light-orange">Schedule <span class="text-muted">So how's it going down?</span></h2>
 
-        <p class="lead schedule-time light-orange schedule-bold">10:30 AM - 11:20 AM</p>
-        <p class="lead schedule-middle schedule-bold">Edwin Roa, Charlottesville</p>
-        <p class="lead schedule-item">Kizomba</p>
 
-        <p class="lead schedule-time light-orange schedule-bold">11:30 AM - 12:20 PM</p>
-        <p class="lead schedule-middle schedule-bold">Brian Le, DC</p>
-        <p class="lead schedule-item">Modern/Urban Bachata</p>
+        {% for workshop in site.data.schedule %}
 
-        <p class="lead schedule-time light-orange schedule-bold">12:30 PM - 1:20 PM</p>
-        <p class="lead schedule-middle schedule-bold">Shaka Brown, DC</p>
-        <p class="lead schedule-middle">Salsa On1 Partnerwork</p>
+            <p class="lead schedule-time light-orange schedule-bold">{{ workshop.time }}</p>
 
-        <p class="lead schedule-time light-orange schedule-bold">1:30 PM - 2:20 PM</p>
-        <p class="lead schedule-middle schedule-bold">Allison Hurst and Sam Woloszynski, Boston and DC</p>
-        <p class="lead schedule-item">On2 Salsa</p>
+            <p class="lead schedule-middle schedule-bold">{{ workshop.title }}</p>
 
-        <p class="lead schedule-time light-orange schedule-bold">2:30 PM - 3:20 PM</p>
-        <p class="lead schedule-middle schedule-bold">Stephen Jackson, Virginia</p>
-        <p class="lead schedule-item">Sensual Bachata</p>
-
-        <p class="lead schedule-time light-orange schedule-bold">3:30 PM - 4:20 PM</p>
-        <p class="lead schedule-middle schedule-bold">Maria Krupholter, DC</p>
-        <p class="lead schedule-item">Intermediate Salsa On2 Footwork and Partnerwork</p>
-
-        <p class="lead schedule-time light-orange schedule-bold">4:30 PM - 5:20 PM</p>
-        <p class="lead schedule-middle schedule-bold">Orlando Machuca, DC</p>
-        <p class="lead schedule-item">Salsa On1 Partnerwork</p>
-
-        <p class="lead schedule-time light-orange schedule-bold">5:30 PM - 6:20 PM</p>
-        <p class="lead schedule-middle schedule-bold">Shaka Brown, DC</p>
-        <p class="lead schedule-item">On2 Cha-cha</p>
-
-        <p class="lead schedule-time light-orange schedule-bold">6:30 PM - 8:30 PM</p>
-        <p class="lead schedule-item schedule-bold">Dinner Break</p>
-
-        <p class="lead schedule-time light-orange schedule-bold">8:30 PM - 10:30 PM</p>
-        <p class="lead schedule-item schedule-bold">Social Dancing with DJ Greene</p>
+            {% if workshop.description %}
+                {% if workshop.description_line_two %}
+                    <p class="lead schedule-middle">{{ workshop.description }}</p>
+                    <p class="lead schedule-item">{{ workshop.description_line_two }}</p>
+                {% else %}
+                    <p class="lead schedule-item">{{ workshop.description }}</p>
+                {% endif %}
+            {% endif %}
 
 
-        <p class="lead schedule-time light-orange schedule-bold">10:30 PM - 11:00 PM</p>
-        <p class="lead schedule-middle schedule-bold">Performances</p>
-        <p class="lead schedule-middle">Featuring DNC 2 BEAT, </p>
-        <p class="lead schedule-item">Yamulee Project DC, and UVA Salsa Club</p>
-
-        <p class="lead schedule-time light-orange schedule-bold">11:00 PM - 2:00 AM</p>
-        <p class="lead schedule-item schedule-bold">Social Dancing with DJ Greene!</p>
+        {% endfor %}
 
         <br>
 

--- a/_includes/tickets.html
+++ b/_includes/tickets.html
@@ -17,7 +17,7 @@
     {% if site.data.global.show_online_ticketing %}
         <div class="jumbotron jumbotron-custom">
           <p><a class="btn btn-lg btn-success cushion" href="{{ site.data.global.ticket_url }}" role="button" target="_blank" rel="noopener">Get tickets!</a></p>
-          <p class="lead schedule-time cushion">Online ticketing will close {{ site.data.global.online_ticket_deadline }}. Tickets at the door are cash only.</p>
+          <p class="lead schedule-time cushion">Online ticketing will close {{ site.data.global.online_ticket_deadline }}. Tickets are available at the door.</p>
         </div>
     {% else %}
         <p class="lead schedule-time cushion">Tickets at the door are cash only.</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
       <a id="about"></a>
       <div class="row featurette">
         <div class="col-md-10 col-md-offset-1">
-          <h2 class="featurette-heading light-orange">What is University Salsa Fest? <span class="text-muted">1&nbsp;day, 8&nbsp;workshops, and 1&nbsp;awesome party!</span></h2>
+          <h2 class="featurette-heading light-orange">What is University Salsa Fest? <span class="text-muted">1&nbsp;day, {{ site.data.global.workshop_count }}&nbsp;workshops, and 1&nbsp;awesome party!</span></h2>
           <p class="lead justified">The University Salsa Fest brings the best of Virginia's salsa scene together in Charlottesville, Virginia. Join us for a full day of workshops and a night of social dancing featuring DJ Steve Greene. Come dance with salseros from Charlottesville, Richmond, Blacksburg, Fairfax, Roanoke, Lynchburg, DC, Philadelphia, Atlanta, and beyond!</p>
           <iframe class="center-aligned" width="100%" height="320" src="https://www.youtube.com/embed/iTInz_2xPJM" frameborder="0" allowfullscreen></iframe>
           <p class="right-aligned cushion"><a href="#top" class="scrollToTop">Back to top  <span class="glyphicon glyphicon-circle-arrow-up"></span></a></p>


### PR DESCRIPTION
### What
- Moved schedule info into a data file and displayed with a loop
- Updated schedule information for 2019
- Changed "8 workshops" to "7 workshops"
- Changed line about at-the-door tickets to remove "cash-only" note
